### PR TITLE
Deobfuscate activation callback URL

### DIFF
--- a/dashboard/js/rad_dashboard.js
+++ b/dashboard/js/rad_dashboard.js
@@ -1,8 +1,7 @@
 (function($){
 
 	jQuery(document).ready(function($) {
-		var server = 'moc.topsppa.revres-ygolodipar//:sptth';
-		server = server.split('').reverse().join('');
+		var server = 'https://rapidology-server.appspot.com';
 		var goto_mode = function(mode) {
 			var $radActScr = $('.rad_act_scr');
             switch (mode) {


### PR DESCRIPTION
Unless there's a really good reason to be obfuscating the URL, obfuscating the command and control server for this plugin makes it look like you are distributing malware.